### PR TITLE
ci: update the release workflow to ensure finalize runs after the image creation

### DIFF
--- a/.github/workflows/flow-release-httpd-oidc-images.yaml
+++ b/.github/workflows/flow-release-httpd-oidc-images.yaml
@@ -104,6 +104,7 @@ jobs:
     runs-on: swirldslabs-infrastructure-linux-medium
     needs:
       - safety-checks
+      - httpd-oidc-images
     if: ${{ github.event.inputs.dry-run-enabled != 'true' && github.ref_name == 'main' }}
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Description

This pull request changes the following:

* update the release workflow to ensure finalize runs after the image creation

### Related Issues

* Closes #3 
