### PR TITLE
fix: ensure workflow uses same versions as docker definition

### DIFF
--- a/.github/workflows/zxc-build-httpd-oidc-images.yaml
+++ b/.github/workflows/zxc-build-httpd-oidc-images.yaml
@@ -28,13 +28,13 @@ on:
         description: "Operating System Image:"
         type: string
         required: false
-        default: "noble-20240801"
+        default: "noble-20250619"
 
       gcs-fuse-version:
         description: "GCS Fuse Version:"
         type: string
         required: false
-        default: "2.4.0"
+        default: "3.0.1"
 
       ## Linux Architectures for Multi-Arch Builds
       platforms:


### PR DESCRIPTION
## Description

This pull request updates default values in the `.github/workflows/zxc-build-httpd-oidc-images.yaml` file to reflect newer versions of the operating system image and GCS Fuse.

Version updates:

* Updated the default operating system image from `noble-20240801` to `noble-20250619`.
* Updated the default GCS Fuse version from `2.4.0` to `3.0.1`.

### Related Issues

* Closes #21
