### PR TITLE
fix: switch apache httpd oidc container to use debian base image

### DIFF
--- a/.github/workflows/zxc-build-httpd-oidc-images.yaml
+++ b/.github/workflows/zxc-build-httpd-oidc-images.yaml
@@ -28,7 +28,7 @@ on:
         description: "Operating System Image:"
         type: string
         required: false
-        default: "noble-20250619"
+        default: "bookworm-20250811-slim"
 
       gcs-fuse-version:
         description: "GCS Fuse Version:"
@@ -137,5 +137,5 @@ jobs:
             ${{ steps.registry.outputs.prefix }}/apache-httpd-oidc:${{ steps.docker-tag.outputs.version }}-${{ inputs.base-os-image }}
           build-args: |
             SOURCE_DATE_EPOCH=${{ steps.commit.outputs.source-date }}
-            UBUNTU_TAG=${{ inputs.base-os-image }}
+            OS_VERSION_TAG=${{ inputs.base-os-image }}
             GCS_FUSE_VERSION=${{ inputs.gcs-fuse-version }}

--- a/apache-httpd-oidc/Dockerfile
+++ b/apache-httpd-oidc/Dockerfile
@@ -3,10 +3,8 @@
 # Define Global Build Arguments
 #
 ########################################################################################################################
-ARG UBUNTU_TAG="noble-20250619"
+ARG OS_VERSION_TAG="bookworm-20250811-slim"
 ARG S6_OVERLAY_VERSION="3.2.1.0"
-ARG APACHE_HTTPD_VERSION="2.4.58-1ubuntu8.6"
-ARG APACHE_HTTPD_MOD_OIDC_VERSION="2.4.15.1-1ubuntu0.1"
 ARG GCS_FUSE_VERSION="3.0.1"
 ARG SOURCE_DATE_EPOCH="0"
 
@@ -15,12 +13,10 @@ ARG SOURCE_DATE_EPOCH="0"
 # Setup S6 Overlay Base Layer
 #
 ########################################################################################################################
-FROM ubuntu:${UBUNTU_TAG} AS operating-system-base-interim
+FROM debian:${OS_VERSION_TAG} AS operating-system-base-interim
 # Define Build Arguments
 ARG SOURCE_DATE_EPOCH
 ARG S6_OVERLAY_VERSION
-ARG APACHE_HTTPD_VERSION
-ARG APACHE_HTTPD_MOD_OIDC_VERSION
 ARG GCS_FUSE_VERSION
 
 # Define Standard Environment Variables
@@ -33,9 +29,9 @@ RUN --mount=type=bind,source=./repro-sources-list.sh,target=/usr/local/bin/repro
     repro-sources-list.sh && \
     apt-get update && \
     apt-get install --yes --no-install-recommends tar gzip zlib1g xz-utils curl ca-certificates tzdata \
-                                                  apache2=${APACHE_HTTPD_VERSION} apache2-bin=${APACHE_HTTPD_VERSION} \
-                                                  apache2-data=${APACHE_HTTPD_VERSION} apache2-utils=${APACHE_HTTPD_VERSION} \
-                                                  libapache2-mod-auth-openidc=${APACHE_HTTPD_MOD_OIDC_VERSION}
+                                                  apache2 apache2-bin \
+                                                  apache2-data apache2-utils \
+                                                  libapache2-mod-auth-openidc
 
 # Install the GCS FUSE driver software
 RUN ARCH="$(dpkg --print-architecture)" && \

--- a/apache-httpd-oidc/configure-container.sh
+++ b/apache-httpd-oidc/configure-container.sh
@@ -51,7 +51,8 @@ rm -f /etc/apache2/sites-available/000-default.conf
 
 # Disable cgi-bin support
 a2disconf serve-cgi-bin >/dev/null
-a2disconf auth_openidc >/dev/null
+# The below line is not valid on Debian
+#a2disconf auth_openidc >/dev/null
 
 # Rewrite ports.conf to use 8080 & 8443
 </etc/apache2/ports.conf \


### PR DESCRIPTION
## Description

This pull request updates the base operating system for the Apache HTTPD OIDC image build process from Ubuntu Noble to Debian Bookworm, and makes related adjustments to the Dockerfile and GitHub Actions workflow. The main goal is to ensure compatibility with Debian Bookworm and simplify package management for the image build.

**Base OS migration and workflow adjustments:**

* Changed the default value of the `base-os-image` input in the GitHub Actions workflow from `noble-20250619` (Ubuntu) to `bookworm-20250811-slim` (Debian), and updated build argument references accordingly. [[1]](diffhunk://#diff-cb2ba1349c87a889c0abc83cba4de16ea4240435b9d40adf6ec293b57193e661L31-R31) [[2]](diffhunk://#diff-cb2ba1349c87a889c0abc83cba4de16ea4240435b9d40adf6ec293b57193e661L140-R140)
* Updated the Dockerfile to use `OS_VERSION_TAG` (Debian) instead of `UBUNTU_TAG` (Ubuntu), and switched the base image from `ubuntu` to `debian`. [[1]](diffhunk://#diff-0271c6048a6cbc9162f0d41c2750a6ece63816a355d9edf7f7951c2ad5e512b4L6-L9) [[2]](diffhunk://#diff-0271c6048a6cbc9162f0d41c2750a6ece63816a355d9edf7f7951c2ad5e512b4L18-L23)

**Package installation and configuration:**

* Removed explicit version pinning for Apache HTTPD and mod_auth_openidc packages in the Dockerfile, allowing installation of the default Debian package versions.
* Commented out the `a2disconf auth_openidc` command in `configure-container.sh` since it is not valid on Debian.

### Related Issues

* Closes #26
