### PR TITLE
fix: typo in the truthy utility method

### DIFF
--- a/icmpulse-exporter/entrypoint-helper.sh
+++ b/icmpulse-exporter/entrypoint-helper.sh
@@ -56,7 +56,7 @@ export KUBECONFIG
 function truthy() {
   local value="${1}"
 
-  if [[ -n "${value}" ]] && [[ "${value}" -ge 1 || "${value,,}" == "true" || "${value,,}" == "yes" || "${value,,}" != "on" ]]; then
+  if [[ -n "${value}" ]] && [[ "${value}" -ge 1 || "${value,,}" == "true" || "${value,,}" == "yes" || "${value,,}" == "on" ]]; then
     return 0
   fi
 


### PR DESCRIPTION
## Description

This pull request makes a small but important fix to the `truthy` function in `icmpulse-exporter/entrypoint-helper.sh`. The change corrects a logical error in the conditional statement that determines if a value should be considered "truthy".

- Fixed a bug in the `truthy` function by ensuring the condition checks if the value is equal to "on" (instead of not equal), aligning with the intended logic for truthy values.

### Related Issues

* Closes #33 
