### PR TITLE
fix: set capabilities on ping exporter during container build

### DIFF
--- a/icmpulse-exporter/Dockerfile
+++ b/icmpulse-exporter/Dockerfile
@@ -106,7 +106,8 @@ RUN set -eux; \
         tar -C /usr/local/bin/ -xzf /tmp/ping_exporter.tar.gz ping_exporter; \
         rm -f /tmp/ping_exporter.tar.gz; \
         chmod +x /usr/local/bin/ping_exporter; \
-        mkdir -p /etc/icmpulse/
+        mkdir -p /etc/icmpulse/; \
+        setcap 'cap_net_raw+ep' /usr/local/bin/ping_exporter
 
 # Add the ping_exporter configuration template
 ADD conf/config.tpl.yaml /etc/icmpulse/config.tpl.yaml

--- a/icmpulse-exporter/s6-rc.d/ping-exporter/run
+++ b/icmpulse-exporter/s6-rc.d/ping-exporter/run
@@ -5,7 +5,8 @@ set -eo pipefail
 # Import helper functions
 source /usr/local/bin/entrypoint-helper.sh
 
-setcap 'cap_net_raw+ep' /usr/local/bin/ping_exporter || true
+# Best effort to ensure the capabilities are set correctly
+setcap 'cap_net_raw+ep' /usr/local/bin/ping_exporter >/dev/null 2>&1 || true
 
 ### Execute Ping Exporter ###
 exec_with_context /usr/local/bin/ping_exporter --config.path=/var/run/icmpulse/config.yaml "${@}"


### PR DESCRIPTION
## Description

This pull request ensures that the `ping_exporter` binary has the necessary network capabilities (`cap_net_raw`) set at build time in the Docker image, rather than relying on runtime scripts. It also makes the runtime capability-setting step quieter and more robust.

**Container build improvements:**

* The Dockerfile now sets the `cap_net_raw` capability on `/usr/local/bin/ping_exporter` during the image build, ensuring it can send raw network packets without requiring root at runtime.

**Runtime script robustness:**

* The `ping-exporter` service run script now suppresses errors and output when attempting to set capabilities, making it a quiet, best-effort operation in case the capability was not set at build time.

### Related Issues

* Closes #33
