### PR TITLE
fix: pass command line only configuration correctly

### DIFF
--- a/icmpulse-exporter/conf/config.tpl.yaml
+++ b/icmpulse-exporter/conf/config.tpl.yaml
@@ -1,18 +1,11 @@
-web:
-  listen-address: {{ getenv "ICMPULSE_WEB_LISTEN_ADDRESS" ":9100" }}
-  telemetry-path: {{ getenv "ICMPULSE_WEB_TELEMETRY_PATH" "/metrics" }}
-
 ping:
-  interval: {{ getenv "ICMPULSE_PING_INTERVAL" "10s" }}
-  timeout: {{ getenv "ICMPULSE_PING_TIMEOUT" "5s" }}
-  size: {{ getenv "ICMPULSE_PING_SIZE" "56" }}
+  interval: {{ getenv "ICMPULSE_PING_INTERVAL" "10s" | quote }}
+  timeout: {{ getenv "ICMPULSE_PING_TIMEOUT" "5s" | quote }}
+  payload-size: {{ getenv "ICMPULSE_PING_SIZE" "56" }}
   history-size: {{ getenv "ICMPULSE_PING_HISTORY_SIZE" "20" }}
 
 dns:
-  refresh: {{ getenv "ICMPULSE_DNS_REFRESH" "5m" }}
-
-log:
-  level: {{ getenv "ICMPULSE_LOG_LEVEL" "info" }}
+  refresh: {{ getenv "ICMPULSE_DNS_REFRESH" "5m" | quote}}
 
 metrics:
   deprecated: disabled

--- a/icmpulse-exporter/entrypoint-helper.sh
+++ b/icmpulse-exporter/entrypoint-helper.sh
@@ -353,7 +353,7 @@ function load_changed_file() {
   return 0
 }
 
-function exec_with_context() {
+function with_context() {
   local s6_command="s6-setuidgid icmpulse"
 
   set +e
@@ -371,4 +371,15 @@ function exec_with_context() {
     log.notice "exec_with_context(): executing command without the icmpulse user context [ ${*} ]"
     exec "${@}"
   fi
+}
+
+function ping_exporter_args() {
+  local argv=""
+
+  [[ -n "${ICMPULSE_WEB_LISTEN_ADDRESS}" ]] && argv="--web.listen-address '${ICMPULSE_WEB_LISTEN_ADDRESS}'"
+  [[ -n "${ICMPULSE_WEB_TELEMETRY_PATH}" ]] && argv="${argv} --web.telemetry-path '${ICMPULSE_WEB_TELEMETRY_PATH}'"
+  [[ -n "${ICMPULSE_LOG_LEVEL}" ]] && argv="${argv} --log.level ${ICMPULSE_LOG_LEVEL}"
+
+  printf "%s" "${argv}" | tr -d '[:space:]'
+  return 0
 }

--- a/icmpulse-exporter/s6-rc.d/ping-exporter/run
+++ b/icmpulse-exporter/s6-rc.d/ping-exporter/run
@@ -8,6 +8,8 @@ source /usr/local/bin/entrypoint-helper.sh
 # Best effort to ensure the capabilities are set correctly
 setcap 'cap_net_raw+ep' /usr/local/bin/ping_exporter >/dev/null 2>&1 || true
 
+# Compute arguments for the ping_exporter
+argv="$(ping_exporter_args)"
+
 ### Execute Ping Exporter ###
-exec_with_context /usr/local/bin/ping_exporter --config.path=/var/run/icmpulse/config.yaml "${@}"
-exit "${?}"
+exec with_context /usr/local/bin/ping_exporter --config.path=/var/run/icmpulse/config.yaml "${argv}" "${@}"


### PR DESCRIPTION
## Description

This pull request updates the configuration templating, refines argument handling for the `ping_exporter` process, and improves script naming consistency. The main changes focus on making configuration values more robust, centralizing argument construction, and cleaning up the entrypoint logic.

**Configuration and Argument Handling Improvements:**

* Updated `icmpulse-exporter/conf/config.tpl.yaml` to quote interval and timeout values and renamed the `ping.size` field to `ping.payload-size` for clarity and consistency. Also, removed the `web` and `log` sections, moving their configuration to command-line arguments.
* Added a new `ping_exporter_args` function in `entrypoint-helper.sh` to build command-line arguments for `ping_exporter` from environment variables, consolidating argument logic in one place.
* Modified the `run` script for `ping-exporter` to use the new `ping_exporter_args` function and pass the constructed arguments to the exporter, improving maintainability and flexibility.

**Script Naming and Refactoring:**

* Renamed the `exec_with_context` function to `with_context` in `entrypoint-helper.sh` for clarity, and updated its usage accordingly.

### Related Issues

* Closes #33
