### PR TITLE
fix: exec issues in the service entrypoint

### DIFF
--- a/icmpulse-exporter/entrypoint-helper.sh
+++ b/icmpulse-exporter/entrypoint-helper.sh
@@ -239,10 +239,8 @@ function generate_exporter_config() {
     return 1
   fi
 
-  set -x
   ${GOMPLATE} -c targets=file://${ICMPULSE_CONF_TARGETS_FILE} -f "${ICMPULSE_CONF_TEMPLATE}" -o "${ICMPULSE_CONF_STAGING_FILE}" >/dev/null 2>&1
   local ec="${?}"
-  set +x
 
   if [[ "${ec}" -ne 0 ]]; then
     log.error "generate_exporter_config(): failed to generate exporter configuration from template (exit code: ${ec})"
@@ -353,7 +351,7 @@ function load_changed_file() {
   return 0
 }
 
-function with_context() {
+function exec_with_context() {
   local s6_command="s6-setuidgid icmpulse"
 
   set +e

--- a/icmpulse-exporter/s6-rc.d/ping-exporter/run
+++ b/icmpulse-exporter/s6-rc.d/ping-exporter/run
@@ -12,4 +12,5 @@ setcap 'cap_net_raw+ep' /usr/local/bin/ping_exporter >/dev/null 2>&1 || true
 argv="$(ping_exporter_args)"
 
 ### Execute Ping Exporter ###
-exec with_context /usr/local/bin/ping_exporter --config.path=/var/run/icmpulse/config.yaml "${argv}" "${@}"
+exec_with_context /usr/local/bin/ping_exporter --config.path=/var/run/icmpulse/config.yaml "${argv}" "${@}"
+exit "${?}"


### PR DESCRIPTION
## Description

This pull request primarily refactors how the `ping_exporter` process is executed by renaming a shell function for clarity and updating its usage throughout the codebase. It also removes unnecessary debugging output from the configuration generation process.

**Refactoring and function renaming:**

* Renamed the `with_context` shell function to `exec_with_context` in `entrypoint-helper.sh` for improved clarity and consistency. Updated all usages to match the new name, including in the `s6-rc.d/ping-exporter/run` script. [[1]](diffhunk://#diff-7a0512d9033bbc147c8c9a2a0aa3748169162e939bbaf1d2d0a7a780b0972c26L356-R354) [[2]](diffhunk://#diff-853679198a2c3e5a5ceb6759143926ec26a0a9e25973d577c119489af96abee4L15-R16)

**Process execution improvements:**

* Ensured the process exit code is properly propagated by explicitly calling `exit "${?}"` after executing `exec_with_context` in the `ping-exporter/run` script.

**Debug output cleanup:**

* Removed unnecessary `set -x` and `set +x` (debug trace output) from the `generate_exporter_config` function in `entrypoint-helper.sh` to reduce log noise.

### Related Issues

* Closes #33
