### PR TITLE
fix: properly trim leading and trailing whitespace from args

### DIFF
--- a/icmpulse-exporter/entrypoint-helper.sh
+++ b/icmpulse-exporter/entrypoint-helper.sh
@@ -63,6 +63,19 @@ function truthy() {
   return 1
 }
 
+
+function rtrim() {
+  sed -E 's/[[:space:]]+$//'
+}
+
+function ltrim() {
+  sed -E 's/^[[:space:]]+//'
+}
+
+function trim() {
+  ltrim | rtrim
+}
+
 function configure_targets() {
   export ICMPULSE_TARGETS_JSON_FILE
   export ICMPULSE_TARGETS_JSON_CONTENT
@@ -378,6 +391,7 @@ function ping_exporter_args() {
   [[ -n "${ICMPULSE_WEB_TELEMETRY_PATH}" ]] && argv="${argv} --web.telemetry-path '${ICMPULSE_WEB_TELEMETRY_PATH}'"
   [[ -n "${ICMPULSE_LOG_LEVEL}" ]] && argv="${argv} --log.level ${ICMPULSE_LOG_LEVEL}"
 
-  printf "%s" "${argv}" | tr -d '[:space:]'
+  printf "%s" "${argv}" | trim
   return 0
 }
+

--- a/icmpulse-exporter/s6-rc.d/ping-exporter/run
+++ b/icmpulse-exporter/s6-rc.d/ping-exporter/run
@@ -12,5 +12,6 @@ setcap 'cap_net_raw+ep' /usr/local/bin/ping_exporter >/dev/null 2>&1 || true
 argv="$(ping_exporter_args)"
 
 ### Execute Ping Exporter ###
-exec_with_context /usr/local/bin/ping_exporter --config.path=/var/run/icmpulse/config.yaml "${argv}" "${@}"
+# shellcheck disable=SC2086
+exec_with_context /usr/local/bin/ping_exporter --config.path=/var/run/icmpulse/config.yaml ${argv} "${@}"
 exit "${?}"


### PR DESCRIPTION
## Description

This pull request adds new string trimming helper functions to `entrypoint-helper.sh` and updates how arguments are formatted in the `ping_exporter_args` function. The main goal is to ensure that whitespace is handled more robustly when preparing command-line arguments.

String trimming utilities:

* Added three new helper functions: `ltrim`, `rtrim`, and `trim` to remove leading, trailing, or both types of whitespace from strings using `sed`.

Argument formatting improvement:

* Updated the `ping_exporter_args` function to use the new `trim` function instead of `tr -d '[:space:]'`, ensuring only leading and trailing whitespace is removed from the constructed argument string, rather than all whitespace.

### Related Issues

* Closes #33
