### PR TITLE
feat: add ip and dns utilities to the icmpulse container image

### DIFF
--- a/icmpulse-exporter/Dockerfile
+++ b/icmpulse-exporter/Dockerfile
@@ -32,7 +32,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN --mount=type=bind,source=./repro-sources-list.sh,target=/usr/local/bin/repro-sources-list.sh \
     repro-sources-list.sh && \
     apt-get update && \
-    apt-get install --yes --no-install-recommends tar gzip zlib1g xz-utils curl ca-certificates tzdata jq libcap2-bin
+    apt-get install --yes --no-install-recommends tar gzip zlib1g xz-utils curl ca-certificates tzdata jq libcap2-bin && \
+    apt-get install --yes --no-install-recommends iputils-ping traceroute iputils-tracepath dnsutils mtr-tiny
 
 ###############################
 ####    KubeCtl Install    ####


### PR DESCRIPTION
## Description

This pull request updates the `icmpulse-exporter/Dockerfile` to improve the container's networking diagnostic capabilities by installing several additional network utilities.

**Dependency additions for network diagnostics:**

* Added installation of `iputils-ping`, `traceroute`, `iputils-tracepath`, `dnsutils`, and `mtr-tiny` to the Docker image, enabling more comprehensive network troubleshooting and monitoring within the container.

### Related Issues

* Closes #49
